### PR TITLE
Export pstream struct also to facilitate importing from a typed racke…

### DIFF
--- a/rsound/stream-play.rkt
+++ b/rsound/stream-play.rkt
@@ -17,7 +17,8 @@
          pstream-current-frame
          pstream-queue-callback
          pstream-volume
-         pstream-set-volume!)
+         pstream-set-volume!
+         (struct-out pstream))
 
 ;; a pstream bundles a sound-heap that's attached
 ;; to a playing stream and a time-checker that returns


### PR DESCRIPTION
…t program

Currently pstream struct is not imported and hence the same can not be used as a opaque type from a typed racket code (as pstream? predicate is not exported as well). This will allow to import inside TR as well.