### PR TITLE
Enables rs-draw on custom frames

### DIFF
--- a/rsound/draw.rkt
+++ b/rsound/draw.rkt
@@ -314,7 +314,7 @@
            "expected two vectors of the same length, got ~s and ~s" 
            (vector-length left-vec)
            (vector-length right-vec)))
-  (vector-display-frame title 
+  (vector-display-frame #f title 
                 (lambda (i) (magnitude (vector-ref left-vec i)))
                 (lambda (i) (magnitude (vector-ref right-vec i)))
                 (vector-length left-vec)
@@ -332,7 +332,7 @@
                           0 arr))
   (define real-parts (array->vector (inline-array-map real-part arr)))
   (define imag-parts (array->vector (inline-array-map imag-part arr)))
-  (vector-display-frame title
+  (vector-display-frame #f title
                         (lambda (i) (vector-ref real-parts i))
                         (lambda (i) (vector-ref imag-parts i))
                         (array-size arr)
@@ -349,7 +349,7 @@
                           0 arr))
   (define magnitude-parts (array->vector (inline-array-map magnitude arr)))
   (define phase-parts (array->vector (inline-array-map phase arr)))
-  (vector-display-frame title
+  (vector-display-frame #f title
                         (lambda (i) (vector-ref magnitude-parts i))
                         (lambda (i) (vector-ref phase-parts i))
                         (array-size arr)
@@ -366,7 +366,7 @@
                           0 arr))
   (define magnitude-parts (array->vector (inline-array-map magnitude arr)))
   (define phase-parts (array->vector (inline-array-map phase arr)))
-  (vector-display-frame title
+  (vector-display-frame #f title
                 (lambda (i) (log (vector-ref magnitude-parts i)))
                 (lambda (i) (vector-ref phase-parts i))
                 (array-size arr)

--- a/rsound/draw.rkt
+++ b/rsound/draw.rkt
@@ -265,9 +265,11 @@
 
 ;; given ... a bunch of stuff, create a new window for displaying vector data
 ;; and show it.
-(define (vector-display-frame title left-getter right-getter len width height data-left
+(define (vector-display-frame frame title left-getter right-getter len width height data-left
                       data-right common-scale?)
-  (let* ([f (new frame% [label title] [width width] [height height])]
+  (let* ([f (if (equal? frame #f)
+                (new frame% [label title] [width width] [height height])
+                frame)]
          [tx (new text%)]
          [ty (new text%)]
          [c (new sound-canvas%
@@ -376,9 +378,10 @@
 
 
 ;; draw a sound
-(define (rs-draw sound #:title [title "picture of sound"] 
-                     #:width [width 800] #:height [height 230])
-  (vector-display-frame title
+(define (rs-draw sound #:title [title "picture of sound"]
+                 #:parent [parent #f]
+                 #:width [width 800] #:height [height 230])
+  (vector-display-frame parent title
                 (lambda (i) (/ (rs-ith/left/s16 sound i) s16max))
                 (lambda (i) (/ (rs-ith/right/s16 sound i) s16max))
                 (rs-frames sound)

--- a/rsound/rsound.scrbl
+++ b/rsound/rsound.scrbl
@@ -322,6 +322,10 @@ These procedures allow the creation, analysis, and manipulation of rsounds.
 
 @defproc[(rs-draw [rsound rsound?]
                       [#:title title string?]
+                      [#:parent parent (or/c (is-a?/c frame%)
+                                             (is-a?/c dialog%) 
+                                             (is-a?/c panel%)
+                                             (is-a?/c pane%))]
                       [#:width width nonnegative-integer? 800]
                       [#:height height nonnegative-integer? 200])
          void?]{

--- a/rsound/test/manual-draw-test.rkt
+++ b/rsound/test/manual-draw-test.rkt
@@ -85,7 +85,7 @@
 
 (let ([lvec (vector 3 4123 2 4 3 2 2 2 4 2 3 4 1 2 2 23  4 3 3)]
       [rvec (vector 3 23 298 4 2 23 1 2 3 4 9 8 2 24 2 79 1 23 9)])
-  (vector-display-frame
+  (vector-display-frame #f
    "non-rsound vectors"
    (lambda (i) (vector-ref lvec i))
    (lambda (i) (vector-ref rvec i))


### PR DESCRIPTION
Add an optional `parent` argument to `rs-draw` to make possible to draw on custom frames/panels.