### PR TITLE
simple trinagle-wave added

### DIFF
--- a/rsound/signals.scrbl
+++ b/rsound/signals.scrbl
@@ -134,6 +134,12 @@ Also note that all of these assume a fixed sample rate of 44.1 KHz.
  frequency, at the default sample rate, of amplitude 1.0.}
 
 @defproc[#:kind "signal"
+                (triangle-wave [frequency nonnegative-number?]) real?]{
+ A signal representing a naive triangle wave of the given
+ frequency, of amplitude 1.0. Note that since this is a simple -1.0 up to 1.0 triangle wave, it's got horrible 
+ aliasing all over the spectrum.}
+
+@defproc[#:kind "signal"
                 (sawtooth-wave [frequency nonnegative-number?]) real?]{
  A signal representing a naive sawtooth wave of the given
  frequency, of amplitude 1.0. Note that since this is a simple -1.0 up to 1.0 sawtooth wave, it's got horrible 

--- a/rsound/util.rkt
+++ b/rsound/util.rkt
@@ -45,6 +45,7 @@ rsound-max-volume
          rs-mult
          twopi
          sine-wave
+	 triangle-wave
          sawtooth-wave
          approx-sawtooth-wave
          square-wave
@@ -348,6 +349,25 @@ rsound-max-volume
               (* 0.5 (sin (* twopi 2.0 pitch ctr)))
               (* 0.25 (sin (* twopi 3.0 pitch ctr)))))))
 
+;; SYNTHESIS OF TRIANGLE WAVES:
+
+(define triangle-wave
+  (let ([direction 'up])
+    (define (increment p freq)
+      (define next (if (equal? direction 'up)
+                       (+ p (* 2.0 freq SRINV))
+                       (- p (* 2.0 freq SRINV))))        
+      (cond [(and (>= next 1.0) (equal? direction 'up))
+             (set! direction 'down)]
+            [(and (<= next -1.0) (equal? direction 'down))
+             (set! direction 'up)])
+      next)
+    (network (freq)
+      [_ = (unless (number? freq)
+             (raise-argument-error 'triangle-wave "number" 0 freq))]
+      [b   = (prev a -1.0)]
+      [a   = (increment b freq)]
+      [out = b])))
 
 ;; SYNTHESIS OF SAWTOOTH WAVES:
 


### PR DESCRIPTION
Thanks. This library is awesome.

test:
```racket
(require rsound)
(define sig1
  (network ()
           [a <= triangle-wave 560]
           [out = (* 0.1 a)]))
 
(play (signal->rsound 441000 sig1))
```